### PR TITLE
Fix default output-dir

### DIFF
--- a/generator/cli.py
+++ b/generator/cli.py
@@ -115,6 +115,7 @@ def kubernetes():
 )
 @click.option(
     "--out-dir",
+    default=".",
     help="Path to output directory.",
 )
 @click.option(

--- a/generator/discovery/csp_generator.py
+++ b/generator/discovery/csp_generator.py
@@ -56,7 +56,7 @@ class CspGenerator:
         # request Gaia-X compliance credential for CSP as Legal Person
         print('Request VC of type "gx:compliance" for CSP at GXDCH Compliance Service...', end='')
         vp = credentials.convert_to_vp(creds=[tandc_vc, lrn_vc, lp_vc])
-        cs_vc = self.compliance.request_compliance_vc(vp, self.cred_base_url + "/csp_compliance.json")
+        cs_vc = self.compliance.request_compliance_vc(json.dumps(vp), self.cred_base_url + "/csp_compliance.json")
         print('ok')
         return {'tandc': tandc_vc, 'lrn': lrn_vc, 'lp': lp_vc, 'cs_csp': json.loads(cs_vc), 'vp_csp': vp}
 

--- a/generator/discovery/csp_generator.py
+++ b/generator/discovery/csp_generator.py
@@ -56,7 +56,7 @@ class CspGenerator:
         # request Gaia-X compliance credential for CSP as Legal Person
         print('Request VC of type "gx:compliance" for CSP at GXDCH Compliance Service...', end='')
         vp = credentials.convert_to_vp(creds=[tandc_vc, lrn_vc, lp_vc])
-        cs_vc = self.compliance.request_compliance_vc(json.dumps(vp), self.cred_base_url + "/csp_compliance.json")
+        cs_vc = self.compliance.request_compliance_vc(vp, self.cred_base_url + "/csp_compliance.json")
         print('ok')
         return {'tandc': tandc_vc, 'lrn': lrn_vc, 'lp': lp_vc, 'cs_csp': json.loads(cs_vc), 'vp_csp': vp}
 


### PR DESCRIPTION
While trying to generate credentials for CSPs with

```
python3 -m generator.cli csp
```

I received the following unexpected error:

```
Traceback (most recent call last):
  File "/home/anja-strunk/Repos/SCS/gx-credential-generator/generator/cli.py", line 363, in <module>
    cli_commands()
  File "/home/anja-strunk/VirtualEnv/scs/gx-credential-generator/lib/python3.10/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
  File "/home/anja-strunk/VirtualEnv/scs/gx-credential-generator/lib/python3.10/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
  File "/home/anja-strunk/VirtualEnv/scs/gx-credential-generator/lib/python3.10/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/anja-strunk/VirtualEnv/scs/gx-credential-generator/lib/python3.10/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/anja-strunk/VirtualEnv/scs/gx-credential-generator/lib/python3.10/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "/home/anja-strunk/Repos/SCS/gx-credential-generator/generator/cli.py", line 88, in wrapper
    return func(*args, **kwargs)
  File "/home/anja-strunk/Repos/SCS/gx-credential-generator/generator/cli.py", line 196, in csp
    _print_vcs(vcs, out_dir)
  File "/home/anja-strunk/Repos/SCS/gx-credential-generator/generator/cli.py", line 308, in _print_vcs
    if not os.path.isdir(out_dir):
  File "/usr/lib/python3.10/genericpath.py", line 42, in isdir
    st = os.stat(s)
TypeError: stat: path should be string, bytes, os.PathLike or integer, not NoneType
```

The problem was, missing `out-dir` value for command `csp`.

A further bug was wrong formatted request to compliance service, resulting in an HTTP 409. 