### PR TITLE
Log HTTP error messages from compliance API

### DIFF
--- a/generator/discovery/gxdch_services.py
+++ b/generator/discovery/gxdch_services.py
@@ -1,4 +1,5 @@
 import json
+import logging
 
 import requests
 
@@ -15,7 +16,11 @@ class ComplianceService:
 
     def request_compliance_vc(self, vp: dict, vp_id) -> str:
         resp = requests.post(self.api + "/api/credential-offers?vcid=" + vp_id, json.dumps(vp))
-        resp.raise_for_status()
+        try:
+            resp.raise_for_status()
+        except requests.exceptions.HTTPError as err:
+            logging.error(resp.text)
+            raise err
         return resp.text
 
 

--- a/tests/test_gxdch_services.py
+++ b/tests/test_gxdch_services.py
@@ -1,6 +1,6 @@
 import unittest
 import uuid
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 from requests.exceptions import HTTPError
 
@@ -80,10 +80,13 @@ class GxdchTestCase(unittest.TestCase):
     @patch("requests.post")
     def test_request_compliance_vc_exception(self, post_mock):
         # init test
-        post_mock.side_effect = HTTPError(409)
+        resp = MagicMock()
+        resp.raise_for_status.side_effect = HTTPError(409)
+        post_mock.return_value = resp
 
         # run test
         comp_serv = ComplianceService("https://example.com/gxdch/compliance-service")
+
 
         # Check results
         self.assertRaises(HTTPError, comp_serv.request_compliance_vc, vp="{\\\"foo\\\": \\\"bar\\\"}",

--- a/tests/test_gxdch_services.py
+++ b/tests/test_gxdch_services.py
@@ -1,6 +1,6 @@
 import unittest
 import uuid
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 from requests.exceptions import HTTPError
 

--- a/tests/test_gxdch_services.py
+++ b/tests/test_gxdch_services.py
@@ -87,7 +87,6 @@ class GxdchTestCase(unittest.TestCase):
         # run test
         comp_serv = ComplianceService("https://example.com/gxdch/compliance-service")
 
-
         # Check results
         self.assertRaises(HTTPError, comp_serv.request_compliance_vc, vp="{\\\"foo\\\": \\\"bar\\\"}",
                           vp_id="example.json")


### PR DESCRIPTION
While testing https://github.com/SovereignCloudStack/gx-credential-generator/pull/116 I eventually managed to get into a 409 error myself. Problem was that my LetsEncrypt certificate had expired. However, I only received the following output:

```
INFO: Request VC of type "gx:compliance" for CSP at GXDCH Compliance Service...
Traceback (most recent call last):
    ...
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 409 Client Error: Conflict for url: https://compliance.lab.gaia-x.eu/v1-staging/api/credential-offers?vcid=https://gaia-x-testing.cloudandheat.com/csp_compliance.json
```

I added logging of the actual received message in the HTTP body in case of error responses. It now looks like this:

```
INFO: Request VC of type "gx:compliance" for CSP at GXDCH Compliance Service...
ERROR: {"message":"X509 certificate chain could not be resolved against registry trust anchors for VC https://gaia-x-testing.cloudandheat.com/tandc.json.","error":"Conflict","statusCode":409}
Traceback (most recent call last):
    ...
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 409 Client Error: Conflict for url: https://compliance.lab.gaia-x.eu/v1-staging/api/credential-offers?vcid=https://gaia-x-testing.cloudandheat.com/csp_compliance.json
```